### PR TITLE
Implement nethuns_send and fix nethuns_bind for netmap

### DIFF
--- a/src/nethuns/sockets/netmap.c
+++ b/src/nethuns/sockets/netmap.c
@@ -159,7 +159,7 @@ int nethuns_bind_netmap(struct nethuns_socket_netmap *s, const char *dev, int qu
     }
     else
     {
-        snprintf(nm_dev, NMDEVSZ, "netmap:%s-%d%s", dev, nethuns_socket(s)->queue, flags);
+        snprintf(nm_dev, NMDEVSZ, "netmap:%s-%d%s", dev, queue, flags);
     }
 
     s->p = nmport_prepare(nm_dev);


### PR DESCRIPTION
Add the implementation of nethuns_send_netmap, and fix the queue number used in nethuns_bind_netmap.