### PR TITLE
Update the readme file with a description of the two use cases implemented with nethuns

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 # Nethuns: a unified API for fast and portable network programming
 
 # Introduction
-Nethuns is a software library written in C that provides a unified API to access and manage low-level network operations over different underlying network sockets and operating systems. The design of Nethuns originates from the practical requirement of developing portable network applications with extremely high data rate target. Instead of re-writing the applications to match the underlying sockets available over the different operating systems, Nethuns offers a unified abstraction layer that allows programmers to implement their applications regardless of the underlying technology. Therefore, network applications that use the Nethuns library only need to be re-compiled to run on top of a different socket (chosen in the set of the ones available for the OS), with no need for code adaptation.
+Nethuns is a software library written in C that provides a unified API to access and manage low-level network operations over different underlying network I/O frameworks, and consequently operating systems. The design of Nethuns originates from the practical requirement of developing portable network applications with extremely high data rate target. Instead of re-writing the applications to match the underlying network I/O engines available over the different operating systems, Nethuns offers a unified abstraction layer that allows programmers to implement their applications regardless of the underlying technology. Therefore, network applications that use the Nethuns library only need to be re-compiled to run on top of a different engine (chosen in the set of the ones available for the OS), with no need for code adaptation.
 
-Nethuns would like to fill the lack of a <i>unified network abstraction</i> in the software domain, which is instead present in the hardware domain thanks to [P4](https://p4.org/). Nethuns should play a similar role to that entrusted to the [pcap](https://www.tcpdump.org/) library in the past. In addition, it adds support for recent technologies such as [AF_XDP](https://www.kernel.org/doc/Documentation/networking/af_xdp.rst) and concurrency. Of course, all of this is provided to network programmers while minimizing the overhead, in order not to impact the performance of native underlying sockets.
+Nethuns would like to fill the lack of a <i>unified network abstraction</i> in the software domain, which is instead present in the hardware domain thanks to [P4](https://p4.org/). Nethuns should play a similar role to that entrusted to the [pcap](https://www.tcpdump.org/) library in the past. In addition, it adds support for recent technologies such as [AF_XDP](https://www.kernel.org/doc/Documentation/networking/af_xdp.rst) and concurrency. Of course, all of this is provided to network programmers while minimizing the overhead, in order not to impact the performance of native underlying network I/O frameworks. The API exposed by Nethuns recalls the interface of UNIX sockets to make immediate and simple its adoption to experienced network programmers.
 
 Nethuns fully supports:
 * AF_PACKET and [AF_XDP](https://www.kernel.org/doc/Documentation/networking/af_xdp.rst) sockets for fast packet handling over Linux
@@ -63,12 +63,12 @@ The Nethuns library relies on the following dependencies:
 <br>
 
 # Building the library
-The Nethuns library has to be built against one of the available underlying sockets before you can use it. Assuming to be on a Linux distribution, the build process can be done by executing the following steps from inside the main directory of the project.
+The Nethuns library has to be built against any of the available underlying engines before you can use it. Assuming to be on a Linux distribution, the build process can be done by executing the following steps from inside the main directory of the project:
 ```
 $ mkdir build && cd build
 $ ccmake ..
 ```
-At this point, a configuration menu should appear to the user, which can select the socket to use, as well as set up some other building options (see an example below). 
+At this point, a configuration menu should appear to the user, which can select one or more network I/O frameworks to build among those available, as well as set up some other building options (see an example below). 
 ```
 CMAKE_BUILD_TYPE                 Release
 CMAKE_INSTALL_PREFIX             /usr/local
@@ -76,9 +76,9 @@ LIBPCAP_INCLUDE_DIR              /usr/include
 LIBPCAP_LIBRARY                  /usr/lib/x86_64-linux-gnu/libpcap.a
 NETHUNS_OPT_BUILTIN_PCAP_READER  OFF
 NETHUNS_OPT_LIBPCAP              ON
-NETHUNS_OPT_NETMAP               OFF
+NETHUNS_OPT_NETMAP               ON
 NETHUNS_OPT_TPACKET_V3           OFF
-NETHUNS_OPT_XDP                  OFF
+NETHUNS_OPT_XDP                  ON
 ```
 
 Press `c` to process the configuration files with the current options, `enter` to set the value of a given option, `g` to generate the build files and exit, `q` to quit `ccmake` without generating build files. Once the build files have been generated with the correct options, the library can be finally built and installed (the default path is `/usr/local`) by issuing the commands:
@@ -93,9 +93,10 @@ $ sudo make install
 # Building the examples
 A whole suite of tests can be found under the `/test` directory in this repository. These examples can be used as a starting point to understand how to use the Nethuns API. To develop a new application that uses Nethuns operations, you need to include the header file `nethuns/nethuns.h`.
 
-To build the tests, execute the following steps from inside the main directory of the project.
+To build the tests, you first need to select the engine you actually intend to use among the ones built with the library. After the configuration has been generated, you can use `cmake` as done in the previous steps to compile the library. This translates in executing the following steps from inside the main directory of the project:
 ```
 $ cd test
+$ ccmake .
 $ cmake .
 $ make -j<#cores>
 ```
@@ -160,6 +161,35 @@ To use multiple sockets, you need to <i>i)</i> set up the NIC on the receiver PC
 ```
 PC2~/nethuns/test$ ./nethuns-meter -i ix0
 ```
+
+
+<br>
+
+# Practical use cases
+## Traffic generator: nmreplay over Nethuns ([source code](https://github.com/larthia/nethuns/blob/master/test/src/nmreplay.c))
+A traffic generator has been implemented by porting over Nethuns the [`nmreplay`](https://github.com/luigirizzo/netmap/tree/master/apps/nmreplay) application from the Netmap project. The generator can replay packets from a pcap file at the desired speed, with the possibility of adding configurable packet delays and losses.
+
+The "nethunized" `nmreplay` user-space application has been included in the `/test` directory in this repository and can be run with the following command line options:
+```
+nmreplay  	[-f pcap-file] 				set pcap file to replay
+			[-i netmap-interface] 		set interface to use as output
+			[-b batch size] 			set max batch size for tx
+			[-B bandwidth] 				set bandwidth to use for tx
+			[-D delay] 					add additional delay to packet tx
+			[-L loss] 					simulate packet/bit errors
+			[-w wait-link] 				set wait (seconds) before tx
+			[-v] 						enable verbose mode
+```
+The default batch size for packet transmission is 1 (no batching). 
+
+To test this application, we can use two server machines PC1 and PC2: PC1 replays a pcap file at the highest possible rate by running the "nethunized" `nmreplay`, and PC2 is used as a traffic receiver, running for example the `pkt-gen` Netmap application in rx mode or the `nethuns-meter` application.
+
+
+## Open vSwitch (OVS) over Nethuns ([source code](https://github.com/giuseppelettieri/ovs/tree/nethuns))
+The user-space datapath of OVS accesses network ports through a generic “netdev” interface that defines methods for (batched) rx and tx operations. Available netdev implementations include DPDK and AF_XDP and are available in the official [OVS repository](https://github.com/openvswitch/ovs). To port the OVS software switch over Nethuns, a new `netdev-nethuns` device has been implemented. 
+
+To test the OVS application with the `netdev-nethuns` device, backed by either the `AF_XDP` or the `netmap` engines, we can use two server machines PC1 and PC2. PC1 runs an OVS bridge over two 40 Gbps links (connecting the two machines in our testbed configuration), and PC2 sends minimally sized packets on the first link and measures the packets per second received from the second link.
+
 
 <br>
 


### PR DESCRIPTION
The readme file now contains a description of the two use cases implemented: the porting of the nmreplay application from netmap and the porting of the OVS software switch over nethuns.
Other minor changes have been made to the readme document for the fix of small errors.